### PR TITLE
[StrangerData] Fix error generating values for Long type columns.

### DIFF
--- a/src/StrangerData/Utils/RandomValueGenerator.cs
+++ b/src/StrangerData/Utils/RandomValueGenerator.cs
@@ -39,7 +39,7 @@ namespace StrangerData.Utils
                     return Any.Double(columnInfo.Precision, columnInfo.Scale);
                 case ColumnType.Long:
                     // generates a random long
-                    return Any.Long(1, (int)Math.Pow(10, columnInfo.Precision - 1));
+                    return Any.Long(1, (long)Math.Pow(10, columnInfo.Precision - 1));
                 case ColumnType.Boolean:
                     // generates a random boolean
                     return Any.Boolean();


### PR DESCRIPTION
Fix invalid cast on generating random values for 64-bit integer typed columns (as SQL Server BIGINT).

Fix #45 
Fix #52 

Bug repro steps:
- Create a table containing a BIGINT column on SQL Server database: `CREATE TABLE TestTable (LongColumn BIGINT NOT NULL)`
- Execute code: `var mockedData = new DataFactory<SqlServerDialect>({DatabaseConnectionString}).CreateOne("TestTable");`
- Expected behaviour: Method executes successfully, inserts a random value for `LongColumn` on `TestTable` and `mockedData` containing the value.
- Current behaviour: exception shown in #45 and #52 is being thrown.