### PR TITLE
Change cache to be indexed by connection string and table name

### DIFF
--- a/src/StrangerData/DbDialect.cs
+++ b/src/StrangerData/DbDialect.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace StrangerData
 {
     public abstract class DbDialect : IDbDialect
     {
-        public DbDialect(string connectionString)
+        public string ConnectionString { get; }
+
+        protected DbDialect(string connectionString)
         {
+            this.ConnectionString = connectionString;
         }
 
         public virtual void DeleteAll(Stack<RecordIdentifier> recordIdentifiers)

--- a/src/StrangerData/Generator/TableGenerator.cs
+++ b/src/StrangerData/Generator/TableGenerator.cs
@@ -2,7 +2,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("StrangerData.UnitTests")]
 namespace StrangerData.Generator
 {
     internal class TableGenerator

--- a/src/StrangerData/Generator/TableGenerator.cs
+++ b/src/StrangerData/Generator/TableGenerator.cs
@@ -1,10 +1,7 @@
-﻿using StrangerData;
-using StrangerData.Utils;
+﻿using StrangerData.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace StrangerData.Generator
 {
@@ -24,10 +21,7 @@ namespace StrangerData.Generator
             _depth = depth;
 
             // Try get the column info for this table in memory cache, else, get from dialect and store on cache
-            _tableColumnInfoList = MemoryCache.TryGetFromCache<IEnumerable<TableColumnInfo>>(tableName, () =>
-            {
-                return _dbDialect.GetTableSchemaInfo(tableName);
-            });
+            _tableColumnInfoList = MemoryCache.TryGetFromCache<IEnumerable<TableColumnInfo>>(_dbDialect.ConnectionString, tableName, () => this._dbDialect.GetTableSchemaInfo(tableName));
         }
 
         public TableGenerator(IDbDialect dbDialect, string tableName)

--- a/src/StrangerData/IDbDialect.cs
+++ b/src/StrangerData/IDbDialect.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace StrangerData
 {
     public interface IDbDialect : IDisposable
     {
+        string ConnectionString { get; }
+
         TableColumnInfo[] GetTableSchemaInfo(string tableName);
 
         IDictionary<string, object> Insert(string tableName, IEnumerable<TableColumnInfo> tableSchemaInfo, IDictionary<string, object> values);

--- a/src/StrangerData/Utils/MemoryCache.cs
+++ b/src/StrangerData/Utils/MemoryCache.cs
@@ -1,34 +1,34 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace StrangerData.Utils
 {
     public static class MemoryCache
     {
-        private static IDictionary<string, object> _cache;
+        private static IDictionary<Tuple<string, string>, object> _cache;
 
-        private static IDictionary<string, object> Cache
+        private static IDictionary<Tuple<string, string>, object> Cache
         {
             get
             {
                 if (_cache == null)
-                    _cache = new Dictionary<string, object>();
+                    _cache = new ConcurrentDictionary<Tuple<string, string>, object>();
                 return _cache;
             }
         }
 
-        public static T TryGetFromCache<T>(string key, Func<object> getValue)
+        public static T TryGetFromCache<T>(string primaryKey, string secondaryKey, Func<object> getValue)
             where T : class
         {
-            if (!Cache.ContainsKey(key))
+            Tuple<string, string> compositeKey = new Tuple<string, string>(primaryKey, secondaryKey);
+            
+            if (!Cache.ContainsKey(compositeKey))
             {
-                Cache[key] = getValue();
+                Cache[compositeKey] = getValue();
             }
 
-            return Cache[key] as T;
+            return Cache[compositeKey] as T;
         }
     }
 }

--- a/test/StrangerData.UnitTests/Generator/TableGeneratorTests.cs
+++ b/test/StrangerData.UnitTests/Generator/TableGeneratorTests.cs
@@ -7,7 +7,7 @@ namespace StrangerData.UnitTests.Generator
     public class TableGeneratorTests
     {
         [Fact]
-        public void Constructor_TablesFromDifferentDatabasesWithSameName_GetTableSchemaInfoFromBothDatabases()
+        public void Constructor_TablesFromDatabasesWithDifferentConnectionString_GetTableSchemaInfoFromBothDatabases()
         {
             // Arrange
             Mock<IDbDialect> databaseOneDialectMock = new Mock<IDbDialect>();
@@ -28,6 +28,31 @@ namespace StrangerData.UnitTests.Generator
             // Assert
             databaseOneDialectMock.Verify(d => d.GetTableSchemaInfo(tableName), Times.Once);
             databaseTwoDialectMock.Verify(d => d.GetTableSchemaInfo(tableName), Times.Once);
+        }
+
+        [Fact]
+        public void Constructor_TablesFromDifferentDialectsWithSameConnectionString_GetTableSchemaInfoFromCache()
+        {
+            // Arrange
+            string connectionString = Any.String();
+            string tableName = Any.String();
+
+            Mock<IDbDialect> databaseOneDialectMock = new Mock<IDbDialect>();
+            databaseOneDialectMock.Setup(d => d.ConnectionString)
+                .Returns(connectionString);
+
+            Mock<IDbDialect> databaseTwoDialectMock = new Mock<IDbDialect>();
+            databaseTwoDialectMock.Setup(d => d.ConnectionString)
+                .Returns(connectionString);
+
+            TableGenerator databaseOneTableGenerator = new TableGenerator(databaseOneDialectMock.Object, tableName);
+
+            // Act
+            TableGenerator databaseTwoTableGenerator = new TableGenerator(databaseTwoDialectMock.Object, tableName);
+
+            // Assert
+            databaseOneDialectMock.Verify(d => d.GetTableSchemaInfo(tableName), Times.Once);
+            databaseTwoDialectMock.Verify(d => d.GetTableSchemaInfo(tableName), Times.Never);
         }
     }
 }

--- a/test/StrangerData.UnitTests/Generator/TableGeneratorTests.cs
+++ b/test/StrangerData.UnitTests/Generator/TableGeneratorTests.cs
@@ -1,0 +1,33 @@
+﻿using Moq;
+using StrangerData.Generator;
+using Xunit;
+
+namespace StrangerData.UnitTests.Generator
+{
+    public class TableGeneratorTests
+    {
+        [Fact]
+        public void Constructor_TablesFromDifferentDatabasesWithSameName_GetTableSchemaInfoFromBothDatabases()
+        {
+            // Arrange
+            Mock<IDbDialect> databaseOneDialectMock = new Mock<IDbDialect>();
+            databaseOneDialectMock.Setup(d => d.ConnectionString)
+                .Returns(Any.String());
+
+            Mock<IDbDialect> databaseTwoDialectMock = new Mock<IDbDialect>();
+            databaseTwoDialectMock.Setup(d => d.ConnectionString)
+                .Returns(Any.String());
+
+            string tableName = Any.String();
+
+            TableGenerator databaseOneTableGenerator = new TableGenerator(databaseOneDialectMock.Object, tableName);
+
+            // Act
+            TableGenerator databaseTwoTableGenerator = new TableGenerator(databaseTwoDialectMock.Object, tableName);
+
+            // Assert
+            databaseOneDialectMock.Verify(d => d.GetTableSchemaInfo(tableName), Times.Once);
+            databaseTwoDialectMock.Verify(d => d.GetTableSchemaInfo(tableName), Times.Once);
+        }
+    }
+}

--- a/test/StrangerData.UnitTests/Utils/MemoryCacheTests.cs
+++ b/test/StrangerData.UnitTests/Utils/MemoryCacheTests.cs
@@ -1,0 +1,75 @@
+﻿using FluentAssertions;
+using Moq;
+using StrangerData.Utils;
+using System;
+using Xunit;
+
+namespace StrangerData.UnitTests.Utils
+{
+    public class MemoryCacheTests
+    {
+        public MemoryCacheTests()
+        {
+        }
+
+        [Fact]
+        public void TryGetFromCache_BothKeysNotExists_InvokeFuncAndReturnFuncValue()
+        {
+            // Arrange
+            string expected = Any.String();
+            
+            Mock<Func<object>> funcMock = new Mock<Func<object>>();
+            funcMock.Setup(f => f()).Returns(expected);
+
+            string nonExistentPrimaryKey = Any.String();
+            string nonExistentSecondaryKey = Any.String();
+
+            // Act
+            string actual = MemoryCache.TryGetFromCache<string>(nonExistentPrimaryKey, nonExistentSecondaryKey, funcMock.Object);
+
+            // Assert
+            actual.Should().Be(expected);
+            funcMock.Verify(f => f(), Times.Once);
+        }
+
+        [Fact]
+        public void TryGetFromCache_SecondaryKeyNotExists_ReturnNewValue()
+        {
+            string expected = Any.String();
+
+            Mock<Func<object>> funcMock = new Mock<Func<object>>();
+            funcMock.Setup(f => f()).Returns(expected);
+
+            string primaryKey = Any.String();
+            MemoryCache.TryGetFromCache<string>(primaryKey, Any.String(), () => Any.String());
+
+            string nonExistentSecondaryKey = Any.String();
+
+            // Act
+            string actual = MemoryCache.TryGetFromCache<string>(primaryKey, nonExistentSecondaryKey, funcMock.Object);
+
+            // Assert
+            actual.Should().Be(expected);
+            funcMock.Verify(f => f(), Times.Once);
+        }
+
+        [Fact]
+        public void TryGetFromCache_BothKeysExists_ReturnPreviousValue()
+        {
+            Mock<Func<object>> funcMock = new Mock<Func<object>>();
+            funcMock.Setup(f => f()).Returns(Any.String());
+
+            string primaryKey = Any.String();
+            string secondaryKey = Any.String();
+            string expected = Any.String();
+            MemoryCache.TryGetFromCache<string>(primaryKey, secondaryKey, () => expected);
+
+            // Act
+            string actual = MemoryCache.TryGetFromCache<string>(primaryKey, secondaryKey, funcMock.Object);
+
+            // Assert
+            actual.Should().Be(expected);
+            funcMock.Verify(f => f(), Times.Never);
+        }
+    }
+}

--- a/test/StrangerData.UnitTests/Utils/MemoryCacheTests.cs
+++ b/test/StrangerData.UnitTests/Utils/MemoryCacheTests.cs
@@ -8,10 +8,6 @@ namespace StrangerData.UnitTests.Utils
 {
     public class MemoryCacheTests
     {
-        public MemoryCacheTests()
-        {
-        }
-
         [Fact]
         public void TryGetFromCache_BothKeysNotExists_InvokeFuncAndReturnFuncValue()
         {
@@ -33,8 +29,9 @@ namespace StrangerData.UnitTests.Utils
         }
 
         [Fact]
-        public void TryGetFromCache_SecondaryKeyNotExists_ReturnNewValue()
+        public void TryGetFromCache_SecondaryKeyNotExists_InvokeFuncAndReturnFuncValue()
         {
+            // Arrange
             string expected = Any.String();
 
             Mock<Func<object>> funcMock = new Mock<Func<object>>();
@@ -54,8 +51,9 @@ namespace StrangerData.UnitTests.Utils
         }
 
         [Fact]
-        public void TryGetFromCache_BothKeysExists_ReturnPreviousValue()
+        public void TryGetFromCache_BothKeysExists_NotInvokeFuncAndReturnExistentValue()
         {
+            // Arrange
             Mock<Func<object>> funcMock = new Mock<Func<object>>();
             funcMock.Setup(f => f()).Returns(Any.String());
 


### PR DESCRIPTION
Fix #55 

- Changes in-memory cache to be indexed by connection string and table name. Now the DataFactory gets cached table data by a tuple containing the DbDialect connection string and the table name. Once a connection string identifies a server and a database, it was chosen to fix the test scenario described on #55 and a possible test scenario that uses two different servers containing databases and tables with same name.

- Changes the `MemoryCache` internal structure to use a `ConcurrentDictionary` in order to avoid thread-concurrency issues.

- Creates automated tests for `MemoryCache` and `TableGenerator` classes.